### PR TITLE
Update `paraffin` docs

### DIFF
--- a/docs/source/concept/distributed.rst
+++ b/docs/source/concept/distributed.rst
@@ -12,7 +12,6 @@ onto different hardware or software environments.
 For this purpose, the :term:`paraffin` package was developed.
 
 You can use :code:`paraffin submit` to queue the evaluation of the selected stages.
-With :code:`paraffin worker --concurrency 5` you can start 5 workers to evaluate the stages.
 
 Further, you can select which stage should be picked up by which worker by defining a :code:`paraffin.yaml` file which supports wildcards.
 


### PR DESCRIPTION
- [ ] paraffin ui
- [ ] remove info on installing paraffin from source because it needs `bun vite build` now